### PR TITLE
Add synchronous start_sync and run_sync helpers

### DIFF
--- a/docs/api_patterns.md
+++ b/docs/api_patterns.md
@@ -86,15 +86,17 @@ from llmproc import LLMProgram
 # Load program from TOML
 program = LLMProgram.from_toml('examples/openai/gpt-4o-mini.toml')
 
-# Start the process (creates event loop internally for sync calls)
-process = program.start()  
+# Start the process synchronously
+process = program.start_sync()
 
-# Run in synchronous context (creates event loop internally)
-result = process.run('Hello, what can you tell me about Python?')
+# Run in synchronous context
+result = process.run_sync('Hello, what can you tell me about Python?')
 print(process.get_last_message())
 ```
 
-This works because both `start()` and `run()` methods detect if they're being called from a synchronous context and internally create an event loop if needed.
+These `*_sync()` helpers simply execute the asynchronous methods inside
+`asyncio.run`, allowing you to use LLMProc without managing an event loop
+explicitly.
 
 ## Program Compiler API
 

--- a/docs/mcp-feature-status.md
+++ b/docs/mcp-feature-status.md
@@ -70,12 +70,11 @@ from llmproc import LLMProgram
 # Step 1: Load and compile the program
 program = LLMProgram.from_toml("examples/mcp.toml")
 
-# Step 2: Initialize the process (creates event loop internally)
-process = program.start()
+# Step 2: Initialize the process synchronously
+process = program.start_sync()
 
 # Even in synchronous code, full tool support is available
-# The method will automatically create an event loop if needed
-result = process.run("Please search for popular Python repositories on GitHub.")
+result = process.run_sync("Please search for popular Python repositories on GitHub.")
 print(process.get_last_message())
 ```
 

--- a/docs/mcp-feature.md
+++ b/docs/mcp-feature.md
@@ -173,12 +173,11 @@ from llmproc import LLMProgram
 # Step 1: Load and compile the program
 program = LLMProgram.from_toml("examples/mcp.toml")
 
-# Step 2: Initialize the process (creates event loop internally)
-process = program.start()
+# Step 2: Initialize the process synchronously
+process = program.start_sync()
 
 # The run method can be used in synchronous code and will still support tools
-# It automatically creates an event loop when needed
-result = process.run("Please search for popular Python repositories on GitHub.")
+result = process.run_sync("Please search for popular Python repositories on GitHub.")
 print(process.get_last_message())
 ```
 

--- a/docs/program-compiler.md
+++ b/docs/program-compiler.md
@@ -132,7 +132,7 @@ from llmproc import LLMProgram
 
 # Create a program and start the process in one session
 program = LLMProgram.from_toml("path/to/program.toml")
-process = program.start()  # Creates event loop internally for sync calls
+process = program.start_sync()  # Runs start() inside asyncio.run
 ```
 
 ## Validation Features

--- a/src/llmproc/llm_process.py
+++ b/src/llmproc/llm_process.py
@@ -232,6 +232,26 @@ class LLMProcess:
         else:
             return await self._async_run(user_input, max_iterations)
 
+    def run_sync(self, user_input: str, max_iterations: int = None) -> "RunResult":
+        """Synchronous wrapper around :meth:`run`.
+
+        This helper is intended for code that does not already run inside an
+        event loop. It simply executes the private async implementation with
+        :func:`asyncio.run`.
+
+        Args:
+            user_input: The user message to process.
+            max_iterations: Optional maximum iteration count.
+
+        Returns:
+            RunResult object with execution metrics.
+        """
+
+        if max_iterations is None:
+            max_iterations = self.max_iterations
+
+        return asyncio.run(self._async_run(user_input, max_iterations))
+
     async def _async_run(self, user_input: str, max_iterations: int) -> "RunResult":
         """Internal async implementation of run.
 

--- a/src/llmproc/program.py
+++ b/src/llmproc/program.py
@@ -5,6 +5,7 @@ import warnings
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any, List, Optional, Union
+import asyncio
 
 from llmproc.common.access_control import AccessLevel
 
@@ -624,6 +625,21 @@ class LLMProgram:
         from llmproc.program_exec import create_process
 
         return await create_process(self, access_level=access_level)
+
+    def start_sync(self, access_level: Optional[AccessLevel] = None) -> "LLMProcess":  # noqa: F821
+        """Synchronous wrapper around :meth:`start`.
+
+        This helper allows code running outside of an event loop to
+        initialize a process without manually calling ``asyncio.run``.
+
+        Args:
+            access_level: Optional access level for the process.
+
+        Returns:
+            A fully initialized :class:`LLMProcess`.
+        """
+
+        return asyncio.run(self.start(access_level=access_level))
 
 
 # Apply full docstrings to class and methods


### PR DESCRIPTION
## Summary
- add `start_sync()` wrapper to `LLMProgram`
- add `run_sync()` wrapper to `LLMProcess`
- update docs to demonstrate new sync helpers and remove inaccurate event loop text

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*