### PR TITLE
Add link to GitHub Actions examples above Installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ LLMProc: A Unix-inspired operating system for language models. Like processes in
 
 > *`--disallowedTools` allows removing builtin tools, but not MCP tools.
 
+> **Check out our [GitHub Actions examples](#github-actions-examples) to see LLMProc in action!**
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
## Implementation Output

I've successfully implemented the requested change:

1. Added a link to the GitHub Actions examples section just above the Installation section in the README.md file.
2. The link text reads: "**Check out our [GitHub Actions examples](#github-actions-examples) to see LLMProc in action!**"
3. The link points to the existing GitHub Actions examples section using the anchor tag `#github-actions-examples`.
4. Committed the changes with a descriptive commit message.

The implementation is complete and the issue has been resolved. The link now provides a more prominent way for users to discover the GitHub Actions functionality earlier in the README.

## Process Log

<details>
<summary>Work log entries</summary>

- Starting to explore the repository structure to find the README.md file
- Found README.md and analyzed its content. I need to add a link to the GitHub Actions section just above the Installation section.
- The Edit function encountered an error. I'll try a different approach by reading the entire file and then using the Write function to create a new version with the added link.
- I'll now use the Edit function to add the link to the GitHub Actions section just above the Installation section.
- Successfully added the link to the GitHub Actions section just above the Installation section. Now I'll verify the changes.
- There are some untracked files and modifications that are not related to our task. Since we've successfully implemented and committed the requested change, we can ignore these.
</details>

---
Requested in #4
Automated by llmproc GitHub Action
