### PR TITLE
Add link to successful GitHub Action examples higher up in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 LLMProc: A Unix-inspired operating system for language models. Like processes in an OS, LLMs execute instructions, make system calls, manage resources, and communicate with each other - enabling powerful multi-model applications with sophisticated I/O management.
 
+**🔥 Check out our [GitHub Actions examples](#github-actions-examples) to see LLMProc successfully automating code implementation, conflict resolution, and more!**
+
 ## Table of Contents
 
 - [Why LLMProc over Claude Code?](#why-llmproc-over-claude-code)
@@ -32,8 +34,6 @@ LLMProc: A Unix-inspired operating system for language models. Like processes in
 | **Scripting / SDK**         | ✅ Python SDK with function tools    | ❌ JS-only CLI       |
 
 > *`--disallowedTools` allows removing builtin tools, but not MCP tools.
-
-> **Check out our [GitHub Actions examples](#github-actions-examples) to see LLMProc in action!**
 
 ## Installation
 


### PR DESCRIPTION
## Implementation Output

I've successfully implemented the requested changes:

1. Added a prominent link to the GitHub Actions examples section near the top of the README, right after the project description.
2. Enhanced the link text to highlight successful usage examples: "**🔥 Check out our [GitHub Actions examples](#github-actions-examples) to see LLMProc successfully automating code implementation, conflict resolution, and more!**"
3. Removed the duplicate link that was previously in the README to avoid redundancy.
4. Committed the changes with a descriptive commit message.
5. Cleaned up the repository to ensure a clean working tree.

The changes make the GitHub Actions examples more visible to users by placing the link higher up in the README, and the enhanced text provides more context about the successful usage examples that users can find in that section.

## Process Log

<details>
<summary>Work log entries</summary>

- Examined the README.md file and found the GitHub Actions Examples section. Need to add a link to a successful usage example.
- Found GitHub Action examples in the repo. Will add a link to a successful usage example higher up in the README.
- Successfully added a link to GitHub Actions examples section higher up in the README. The link now mentions successful usage examples for code implementation, conflict resolution, and more. Removed the duplicate link that was previously in the README to avoid redundancy. Committed the changes and cleaned up the repository.
</details>

---
Requested in #4
Automated by llmproc GitHub Action
