### PR TITLE
Update README with links to successful GitHub Action usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,13 +119,16 @@ Real-world automation using LLMProc:
 > - `LLMPROC_WRITE_TOKEN`: GitHub personal access token with write permissions (contents, pull-requests)
 
 - **`@llmproc /resolve`** - Automatically resolve merge conflicts
-  [Workflow](.github/workflows/llmproc-resolve.yml) | [LLM Program (yaml)](.github/config/llmproc-resolve-claude.yaml)
+  [Workflow](.github/workflows/llmproc-resolve.yml) | [LLM Program (yaml)](.github/config/llmproc-resolve-claude.yaml) | 
+  [Example Usage](https://github.com/cccntu/llmproc/pull/7#issuecomment-2916710226) | [Result PR](https://github.com/cccntu/llmproc/pull/8)
 
 - **`@llmproc /ask <question>`** - Answer questions on issues/PRs
-  [Workflow](.github/workflows/llmproc-ask.yml) | [LLM Program (yaml)](.github/config/llmproc-ask-claude.yaml)
+  [Workflow](.github/workflows/llmproc-ask.yml) | [LLM Program (yaml)](.github/config/llmproc-ask-claude.yaml) | 
+  [Example Usage](https://github.com/cccntu/llmproc/issues/5#issuecomment-2916673202)
 
 - **`@llmproc /code <request>`** - Implement features from comments
-  [Workflow](.github/workflows/llmproc-code.yml) | [LLM Program (yaml)](.github/config/llmproc-code-claude.yaml)
+  [Workflow](.github/workflows/llmproc-code.yml) | [LLM Program (yaml)](.github/config/llmproc-code-claude.yaml) | 
+  [Example Usage](https://github.com/cccntu/llmproc/issues/4#issuecomment-2916695626) | [Result PR](https://github.com/cccntu/llmproc/pull/6)
 
 ### In Development
 - **OpenAI/Gemini models** - Basic support, tool calling not yet implemented


### PR DESCRIPTION
## Implementation Output

I've successfully completed the requested task:

1. Updated the README.md file to add links to successful usage examples of the GitHub Action:
   - For `/code`, added links to:
     - Usage example: https://github.com/cccntu/llmproc/issues/4#issuecomment-2916695626
     - Result PR: https://github.com/cccntu/llmproc/pull/6
   
   - For `/ask`, added link to:
     - Usage example: https://github.com/cccntu/llmproc/issues/5#issuecomment-2916673202
   
   - For `/resolve`, added links to:
     - Usage example: https://github.com/cccntu/llmproc/pull/7#issuecomment-2916710226
     - Result PR: https://github.com/cccntu/llmproc/pull/8

2. Committed the changes with a descriptive commit message: "Update README with links to successful GitHub Action usage examples"

The README now provides users with concrete examples of how each GitHub Action command is used and what results they produce, making it easier for new users to understand the practical applications of LLMProc.

There are some untracked files (uv.lock and prompt.txt) in the repository, but they are not related to our implementation task and can be safely ignored.

## Process Log

<details>
<summary>Work log entries</summary>

- Starting the task: updating README with usage examples for the GitHub Action
- Found README.md and examined its content. Now I'll update it to add the requested links to examples of successful GitHub Action usage.
- Successfully updated README.md with links to example usages for each GitHub Action command.
- Committed the changes to README.md. There are some untracked files (uv.lock and prompt.txt) but they're not part of our implementation task.
</details>

---
Requested in #10
Automated by llmproc GitHub Action
